### PR TITLE
Issue-1 Resource ordering

### DIFF
--- a/data/AIX.yaml
+++ b/data/AIX.yaml
@@ -1,0 +1,2 @@
+---
+fsutil::nfs_options: null

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,2 @@
 ---
+fsutil::nfs_options: defaults

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,10 +1,13 @@
 ---
-version: 4
-datadir: data
-hierarchy:
-  - name: "OS family"
-    backend: yaml
-    path: "%{facts.os.family}"
+version: 5
 
-  - name: "common"
-    backend: yaml
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: OS family
+    path: "%{facts.os.family}.yaml"
+
+  - name: common
+    path: common.yaml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class fsutil(
   # Class parameters are populated from External(hiera)/Defaults/Fail
   Data $nfs_mounts = {},
   Data $tree = {},
+  Optional[String] $nfs_options = 'defaults',
 ){
 
   if $nfs_mounts =~ Hash and ! empty($nfs_mounts) {

--- a/manifests/mkmount.pp
+++ b/manifests/mkmount.pp
@@ -7,7 +7,8 @@ define fsutil::mkmount(
   String $umask = '0022',
 ){
   fsutil::mkdir_p { $name:
-    umask   => $umask,
+    umask  => $umask,
+    before => File[$name],
   }
   file { $name:
     ensure => directory,

--- a/manifests/mount_nfs.pp
+++ b/manifests/mount_nfs.pp
@@ -1,18 +1,19 @@
 # == Class: fsutil::mount_nfs
 #
 # Mount an NFS share on a directory - make sure the directory exists
-# 
+#
 #
 define fsutil::mount_nfs(
   # parameters are populated from External(hiera)/Defaults/Fail
   String $device, # must be set - no defaults
-  String $options = 'defaults',
+  String $options = $fsutil::nfs_options,
   String $mode = '0755',
   String $umask = '0022',
 ){
     fsutil::mkmount { $name:
-      mode  => $mode,
-      umask => $umask,
+      mode   => $mode,
+      umask  => $umask,
+      before => Mount[$name],
     }
     mount { $name:
       ensure  => mounted,

--- a/metadata.json
+++ b/metadata.json
@@ -40,12 +40,11 @@
     },
     {
       "operatingsystem": "SLES",
-      "operatingsystemrelease": [ 
+      "operatingsystemrelease": [
         "11",
         "12"
      ]
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }
 


### PR DESCRIPTION
This fixes Issue-1 ... now it applies resources in the correct order:

```
Info: Applying configuration version 'f42659a19fd1d2b301290697af59cf76d5963c41'
Notice: /Stage[main]/Fsutil/Fsutil::Mount_nfs_hash[fsutil_nfs_mounts]/Fsutil::Mount_nfs[/mnt/pkg_repo]/Fsutil::Mkmount[/mnt/pkg_repo]/Fsutil::Mkdir_p[/mnt/pkg_repo]/Exec[mkdir_p-/mnt/pkg_repo]/returns: executed successfully
Notice: /Stage[main]/Fsutil/Fsutil::Mount_nfs_hash[fsutil_nfs_mounts]/Fsutil::Mount_nfs[/mnt/pkg_repo]/Mount[/mnt/pkg_repo]/ensure: ensure changed 'unmounted' to 'mounted'
Info: /Stage[main]/Fsutil/Fsutil::Mount_nfs_hash[fsutil_nfs_mounts]/Fsutil::Mount_nfs[/mnt/pkg_repo]/Mount[/mnt/pkg_repo]: Scheduling refresh of Mount[/mnt/pkg_repo]
Info: Mount[/mnt/pkg_repo](provider=parsed): Remounting
Notice: /Stage[main]/Fsutil/Fsutil::Mount_nfs_hash[fsutil_nfs_mounts]/Fsutil::Mount_nfs[/mnt/pkg_repo]/Mount[/mnt/pkg_repo]: Triggered 'refresh' from 1 event
Info: /Stage[main]/Fsutil/Fsutil::Mount_nfs_hash[fsutil_nfs_mounts]/Fsutil::Mount_nfs[/mnt/pkg_repo]/Mount[/mnt/pkg_repo]: Scheduling refresh of Mount[/mnt/pkg_repo]
Notice: Applied catalog in 3.69 seconds
```

NOTE: I tried to add some hieradata to handle AIX nfs_options, but I think the hiera.yaml might need some help. For now, its an easy workaround to add the options to the mounts.